### PR TITLE
Saving meeting date in file name

### DIFF
--- a/zoom_dl/utils.py
+++ b/zoom_dl/utils.py
@@ -40,6 +40,15 @@ def parseOpts():
                               "extension. Default to the filename according "
                               "to Zoom. Extension is automatic."),
                         metavar="filename")
+    PARSER.add_argument("-d", "--filename-add-date",
+                        help=("Add video meeting date if it is specified. "
+                              "Default is not to include the date."),
+                        default=False,
+                        action='store_true')
+    PARSER.add_argument("--user-agent",
+                        help=("Use custom user agent."
+                              "Default is real browser user agent."),
+                        type=str)
     PARSER.add_argument("-p", "--password",
                         help="Password of the video (if any)",
                         metavar="password")

--- a/zoom_dl/zoomdl.py
+++ b/zoom_dl/zoomdl.py
@@ -68,7 +68,6 @@ class ZoomDL():
         text = self.page.text
         meta = dict(re.findall(r'type="hidden" id="([^"]*)" value="([^"]*)"',
                                text))
-
         # if javascript was correctly loaded, look for injected metadata
         meta2_match = re.search("window.__data__ = ({(?:.*\n)*});",
                                 self.page.text)
@@ -105,6 +104,8 @@ class ZoomDL():
         extension = vid_url.split("?")[0].split("/")[-1].split(".")[1]
         name = (self.metadata.get("topic") or
                 self.metadata.get("r_meeting_topic")).replace(" ", "_")
+        if self.args.filename_add_date and self.metadata.get("r_meeting_start_time"):
+            name = name + "-" + self.metadata.get("r_meeting_start_time")
         self._print("Found name is {}, extension is {}"
                     .format(name, extension), 0)
         name = name if clip is None else "{}-{}".format(name, clip)
@@ -135,11 +136,18 @@ class ZoomDL():
             domain = re.match(r"https?://([^.]*\.?)zoom.us", url).group(1)
             self.session.headers.update({
                 'referer': "https://{}zoom.us/".format(domain),  # set referer
-                "User-Agent": ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                               "AppleWebKit/537.36 (KHTML, like Gecko) "
-                               "Chrome/74.0.3729.169 "
-                               "Safari/537.36")  # somehow standard User-Agent
             })
+            if self.args.user_agent is None:
+                self.session.headers.update({
+                    "User-Agent": ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                                   "AppleWebKit/537.36 (KHTML, like Gecko) "
+                                   "Chrome/74.0.3729.169 "
+                                   "Safari/537.36")  # somehow standard User-Agent
+                })
+            else:
+                self.session.headers.update({
+                    "User-Agent": self.args.user_agent
+                })
             self._change_page(url)
             if self.args.password is not None:
                 # that shit has a password


### PR DESCRIPTION
For my use case, all meetings have the same name (topic). I'd like to append the meeting date to the file name, so I don't have to pick distinct names manually.
This PR does it optionally by extracting the "r_meeting_start_time" field and adding new command line argument, but I'm open for suggestions whether it should be by default behavior, especially if we encounter the same named file.

Another addition here is the --user-agent option which allows overwriting user agent. Again it's just in my case though I believe it's true for many people since it's all Zoom platform, but I found that if the real browser user agent is used then it responds mostly javascript and it won't return the metadata fields (r_meeting_start_time and other), so I had to use an unknown user agent.

I think some of this behavior could be default, but I'm not sure if it works like that for everyone, so I added it as options, but I'm open for suggestions what would be better default configuration here.

Example of usage:
```
zoomdl -d --user-agent abc -u <url>
```
this stores file as "topic Sep 18, 2020 4:07 PM Eastern Time (US and Canada).mp4"
