### PR TITLE
Added support for recordmeet security cookie.

### DIFF
--- a/zoom_dl/utils.py
+++ b/zoom_dl/utils.py
@@ -68,6 +68,18 @@ def parseOpts():
                         metavar="level",
                         type=int,
                         default=1)
+    PARSER.add_argument("-r", "--recordmeet",
+                        help=("Enter the _zm_web_recordmeet cookie. "),
+                        type=str,
+                        required=False,
+                        default="",
+                        metavar="recordmeet")
+    PARSER.add_argument("-k", "--kms",
+                        help=("Enter the _zm_kms cookie (for SSO). "),
+                        type=str,
+                        required=False,
+                        default="",
+                        metavar="kms")
     # PARSER.add_argument("-b", "--browser",
     #                     help=("Indicate the browser from which retrieve the "
     #                           "cookies, to bypass passwords and reCAPTCHA. "

--- a/zoom_dl/zoomdl.py
+++ b/zoom_dl/zoomdl.py
@@ -16,8 +16,12 @@ class ZoomDL():
     def __init__(self, args):
         """Init the class."""
         self.args = args
+        self.loglevel = args.log_level
+
         self.session = requests.session()
-        self.loglevel = self.args.log_level
+        if args.recordmeet: self.session.cookies.set("_zm_web_recordmeet", args.recordmeet)
+        if args.kms: self.session.cookies.set("_zm_kms", args.kms)
+
         # self._set_cookies(self.args.browser)
 
     def _print(self, message, level=0):


### PR DESCRIPTION
Hi,

this should add a manual support for [authenticated recorded meetings](https://github.com/Battleman/zoomdl/issues/20#issuecomment-700854788).

I found out that the only required cookie is `_zm_web_recordmeet`.

I added also the support for SSO with `_zm_kms` cookie.

Thanks for this awesome tool!