### PR TITLE
Multiple improvements: Support saving chats & transcripts, refactor `--filename-add-date`, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Grab the dedicated binary `zoomdl.exe`, and launch it using your command line. I
 
 If there is a domain in your url, make sure to include it, it's crucial.
 ## Usage
-`zoomdl [-h] -u/--url 'url' [-f/--fname 'filename'] [-p/--password 'password'] [-c/--count-clips count] [-d/--filename-add-date] [--user-agent 'custom_user_agent]`
+`zoomdl [-h] -u/--url 'url' [-f/--fname 'filename'] [-p/--password 'password'] [-c/--count-clips count] [-d/--filename-add-date] [--user-agent 'custom_user_agent'] [--save-chat (txt|srt)] [--chat-subtitle-dur number] [--save-transcript (txt|srt)] [--dump-pagemeta]`
 * `-u/--url` is mandatory, it represents the URL of the video
 * `-f/--fname` is optional, it is the name of the resulting file _without extension_. If nothing is provided, the default name given by Zoom will be used. Extension (`.mp4`, `.mkv`,... is automatic)
 * `-p/--password` is too optional. Set it when your video has a password.
@@ -68,7 +68,11 @@ If there is a domain in your url, make sure to include it, it's crucial.
   * \> 1 means: download until you reach this number of clip (or the end)
 * `-d/--filename-add-date` will append the date of the recording to the filename. **without effect if `-f` is specified**
 * `--user-agent` (no shorthand notation): lets you specify a custom User-Agent (only do that if you know what you're doing and why)
-* `--cookies` (no shorthand notation): specify the path to a cookie jar file. 
+* `--cookies` (no shorthand notation): specify the path to a cookie jar file.
+* `--save-chat` (no shorthand notation): save chat messages in the meeting to either a plain-text file or `.srt` subtitle file.
+* `--chat-subtitle-dur` (no shorthand notation): set the duration in seconds that a chat message subtitle appears on the screen. The default value is 3 (seconds). Only works when you specify `--save-chat srt`.
+* `--save-transcript` (no shorthand notation): save audio transcripts in the meeting to either a plain-text file or `.srt` subtitle file.
+* `--dump-pagemeta` (no shorthand notation): dump the page's meta data to a json file for further usages. Usually you do not need this.
 
 ### Cookies / SSO / Captcha / Login
 Some videos are protected with more than a password. You require an SSO, or to solve a captcha. The `cookies` option allows you to perform all the steps in a browser, and then use the cookies to access the video. This functionality is similar to Youtube-dl's same option.
@@ -115,8 +119,8 @@ If you wish to build from sources, here is a quick howto. First, you need to clo
 Run the command `./devscript.sh compile`. It basically installs all the dependencies with pip in a temporary directory, then zips it.
 
 ### Windows
-* Install [pyinstaller](https://www.pyinstaller.org/) (usually `pip install -U pyinstaller`) 
-* Run the command `wincompile.bat`. It calls just calls `pyinstaller` and cleans the generated folders and files, leaving only the exe file. 
+* Install [pyinstaller](https://www.pyinstaller.org/) (usually `pip install -U pyinstaller`)
+* Run the command `wincompile.bat`. It calls just calls `pyinstaller` and cleans the generated folders and files, leaving only the exe file.
 
 ## Requirements
 All dependencies are bundled within the executable. This allows to make a standalone execution without need for external libraries.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If there is a domain in your url, make sure to include it, it's crucial.
 * `-d/--filename-add-date` will append the date of the recording to the filename. **without effect if `-f` is specified**
 * `--user-agent` (no shorthand notation): lets you specify a custom User-Agent (only do that if you know what you're doing and why)
 * `--cookies` (no shorthand notation): specify the path to a cookie jar file.
-* `--save-chat` (no shorthand notation): save chat messages in the meeting to either a plain-text file or `.srt` subtitle file.
+* `--save-chat` (no shorthand notation): save chat messages in the meeting to either a plain-text file or `.srt` subtitle file. Known issue for this function: #70
 * `--chat-subtitle-dur` (no shorthand notation): set the duration in seconds that a chat message subtitle appears on the screen. The default value is 3 (seconds). Only works when you specify `--save-chat srt`.
 * `--save-transcript` (no shorthand notation): save audio transcripts in the meeting to either a plain-text file or `.srt` subtitle file.
 * `--dump-pagemeta` (no shorthand notation): dump the page's meta data to a json file for further usages. Usually you do not need this.

--- a/zoom_dl/utils.py
+++ b/zoom_dl/utils.py
@@ -148,4 +148,28 @@ def parseOpts():
     PARSER.add_argument("--cookies", help="Path to a cookies file in Netscape Format",
                         metavar=("path/to/the/cookies.txt"),
                         required=False)
+
+    PARSER.add_argument("--save-chat",
+                        help=("Save chat in the meeting as a plain-text file or .srt subtitle. "
+                              "Specify mode as \"txt\" for plain-text, or \"srt\" for .srt subtitle"),
+                        metavar="mode",
+                        choices=["txt", "srt"],
+                        default=None)
+    PARSER.add_argument("--chat-subtitle-dur",
+                        help="Duration in seconds that a chat message appears on the screen",
+                        metavar="number",
+                        type=_check_positive,
+                        default=3)
+    PARSER.add_argument("--save-transcript",
+                        help=("Save transcripts in the meeting as a plain-text file or .srt subtitle. "
+                              "Specify mode as \"txt\" for plain-text, or \"srt\" for .srt subtitle"),
+                        metavar="mode",
+                        choices=["txt", "srt"],
+                        default=None)
+
+    PARSER.add_argument("--dump-pagemeta",
+                        help="Dump page metas in json format for further usages",
+                        default=False,
+                        action='store_true')
+
     return PARSER.parse_args()

--- a/zoom_dl/zoomdl.py
+++ b/zoom_dl/zoomdl.py
@@ -9,6 +9,7 @@ import demjson
 import requests
 from tqdm import tqdm
 import datetime
+import json
 
 from .utils import ZoomdlCookieJar
 
@@ -31,6 +32,18 @@ class ZoomDL():
             cookiejar = ZoomdlCookieJar(self.args.cookies)
             cookiejar.load()
             self.session.cookies.update(cookiejar)
+
+    @property
+    def recording_name(self):
+        """
+        Return name of the current recording.
+        """
+        name = (self.metadata.get("topic") or
+                self.metadata.get("r_meeting_topic")).replace(" ", "_")
+        if self.args.filename_add_date:
+            recording_start_time = datetime.datetime.fromtimestamp(self.metadata["fileStartTime"] / 1000)
+            name = name + "_" + recording_start_time.strftime("%Y-%m-%d")
+        return name
 
     def _print(self, message, level=0):
         """Print to console, if level is sufficient.
@@ -65,8 +78,6 @@ class ZoomDL():
     def get_page_meta(self) -> dict:
         """Retrieve metadata from the current self.page.
 
-
-
         Returns:
             dict: dictionary of all relevant metadata
         """
@@ -87,6 +98,39 @@ class ZoomDL():
         else:
             self._print("Advanced meta failed", 2)
             # self._print(self.page.text)
+
+        # look for injected chat messages
+        chats = []
+        chat_match = re.findall("window.__data__.chatList.push\(\s*?({(?:.*\n)*?})\s*?\)",
+                                self.page.text)
+        if len(chat_match) > 0:
+            for matched_json in chat_match:
+                try:
+                    message = demjson.decode(matched_json)
+                    chats.append(message)
+                except demjson.JSONDecodeError:
+                    self._print("[WARNING] Error with the meta parsing. This "
+                                "should not be critical. Please contact a dev. " + matched_json, 2)
+        else:
+            self._print("Unable to extract chatList from page", 0)
+        meta["chatList"] = chats
+
+        # look for injected transcripts
+        transcripts = []
+        transcript_match = re.findall("window.__data__.transcriptList.push\(\s*?({(?:.*\n)*?})\s*?\)",
+                                      self.page.text)
+        if len(transcript_match) > 0:
+            for matched_json in transcript_match:
+                try:
+                    message = demjson.decode(matched_json)
+                    transcripts.append(message)
+                except demjson.JSONDecodeError:
+                    self._print("[WARNING] Error with the meta parsing. This "
+                                "should not be critical. Please contact a dev.", 2)
+        else:
+            self._print("Unable to extract transcriptList from page", 0)
+        meta["transcriptList"] = transcripts
+
         self._print("Metas are {}".format(meta), 0)
         if len(meta) == 0:
             self._print("Unable to gather metadata in page")
@@ -106,8 +150,18 @@ class ZoomDL():
             meta["url"] = vid_url_match.group(1)
         return meta
 
+    def dump_page_meta(self, fname, clip:int=None):
+        """
+        Dump page meta in json format to fname.
+        """
+        self._print("Dumping page meta...", 0)
+        filepath = get_filepath(fname, self.recording_name, "json", clip)
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(self.metadata, f)
+        self._print(f"Dumped page meta to '{filepath}'.", 1)
+
     def download_vid(self, fname, clip:int=None):
-        """Download one recording, and save it at fname."""
+        """Download one recording (including videos, chat, and transcripts), and save it at fname."""
         self._print("Downloading filename {}, clip={}".format(fname, str(clip)), 0)
         all_urls = {
             "camera": self.metadata.get("viewMp4Url"),
@@ -122,17 +176,13 @@ class ZoomDL():
             self._print("Found {} screens, downloading all of them".format(len(all_urls)),
                         1)
             self._print(all_urls, 0)
+
         for vid_name, vid_url in all_urls.items():
             extension = vid_url.split("?")[0].split("/")[-1].split(".")[1]
-            name = (self.metadata.get("topic") or
-                    self.metadata.get("r_meeting_topic")).replace(" ", "_")
-            if self.args.filename_add_date:
-                recording_start_time = datetime.datetime.fromtimestamp(self.metadata["fileStartTime"] / 1000)
-                name = name + "_" + recording_start_time.strftime("%Y-%m-%d")
-            self._print("Found name is {}, extension is {}"
-                        .format(name, extension), 0)
+            self._print("Found name is {}, vid_name is {}, extension is {}"
+                        .format(self.recording_name, vid_name, extension), 0)
             vid_name_appendix = f"_{vid_name}" if len(all_urls) > 1 else ""
-            filepath = get_filepath(fname, name, extension, clip, vid_name_appendix)
+            filepath = get_filepath(fname, self.recording_name, extension, clip, vid_name_appendix)
             filepath_tmp = filepath + ".part"
             self._print("Full filepath is {}, temporary is {}".format(
                 filepath, filepath_tmp), 0)
@@ -169,6 +219,64 @@ class ZoomDL():
                 self._print("Status code: {}, file size: {}".format(
                     vid.status_code, total_size), 0)
                 sys.exit(1)
+
+        # save chat
+        if self.args.save_chat is not None:
+            messages = self.metadata["chatList"]
+            if len(messages) == 0:
+                self._print(f"Unable to retrieve chat message from url {self.url} (is there no chat message?)", 2)
+            else:
+                # Convert time string to proper format
+                for message in messages:
+                    message["time"] = shift_time_delta(message["time"])
+
+                if self.args.save_chat == "txt":
+                    filepath = get_filepath(fname, self.recording_name, "txt", clip, ".chat")
+                    with open(filepath, "w", encoding="utf-8") as f:
+                        for idx, message in enumerate(messages):
+                            f.write("[{}] @ {} :\n".format(
+                                message["username"], message["time"]))
+                            f.write(message["content"] + "\n")
+                            if idx + 1 < len(messages):
+                                f.write("\n")
+                elif self.args.save_chat == "srt":
+                    filepath = get_filepath(fname, self.recording_name, "srt", clip, ".chat")
+                    with open(filepath, "w", encoding="utf-8") as f:
+                        for idx, message in enumerate(messages):
+                            end_time = shift_time_delta(message["time"], self.args.chat_subtitle_dur)
+                            f.write(str(idx+1) + "\n")
+                            f.write("{},000 --> {},000\n".format(message["time"], end_time))
+                            f.write(message["username"] + ": " + message["content"] + "\n")
+                            if idx + 1 < len(messages):
+                                f.write("\n")
+                self._print(f"Successfully saved chat into '{filepath}'!", 1)
+
+        # save transcripts
+        if self.args.save_transcript is not None:
+            transcripts = self.metadata["transcriptList"]
+            if len(transcripts) == 0:
+                self._print(f"Unable to retrieve transcript from url {self.url} (is transcript not enabled in this video?)", 2)
+            else:
+                if self.args.save_transcript == "txt":
+                    filepath = get_filepath(fname, self.recording_name, "txt", clip, ".transcript")
+                    with open(filepath, "w", encoding="utf-8") as f:
+                        for idx, transcript in enumerate(transcripts):
+                            f.write("[{}] @ {} --> {} :\n".format(
+                                transcript["username"], transcript["ts"], transcript["endTs"]))
+                            f.write(transcript["text"] + "\n")
+                            if idx + 1 < len(transcripts):
+                                f.write("\n")
+                elif self.args.save_transcript == "srt":
+                    filepath = get_filepath(fname, self.recording_name, "srt", clip, ".transcript")
+                    with open(filepath, "w", encoding="utf-8") as f:
+                        for idx, transcript in enumerate(transcripts):
+                            f.write(str(idx+1) + "\n")
+                            f.write("{} --> {}\n".format(
+                                transcript["ts"].replace(".",","), transcript["endTs"].replace(".",",")))
+                            f.write(transcript["username"] + ": " + transcript["text"] + "\n")
+                            if idx + 1 < len(transcripts):
+                                f.write("\n")
+                self._print(f"Successfully saved transcripts into '{filepath}'!", 1)
 
     def download(self, all_urls):
         """Exposed class to download a list of urls."""
@@ -214,6 +322,8 @@ class ZoomDL():
             filename = self.args.filename
             if count_clips == 1:  # only download this
                 self.download_vid(filename)
+                if self.args.dump_pagemeta:
+                    self.dump_page_meta(filename)
             else:  # download multiple
                 if count_clips == 0:
                     to_download = total_clips  # download this and all nexts
@@ -221,6 +331,8 @@ class ZoomDL():
                     to_download = min(count_clips, total_clips)
                 for clip in range(current_clip, to_download+1):
                     self.download_vid(filename, clip)
+                    if self.args.dump_pagemeta:
+                        self.dump_page_meta(filename, clip)
                     url = self.page.url
                     next_time = str(self.metadata["nextClipStartTime"])
                     if next_time != "-1":
@@ -312,3 +424,40 @@ def get_filepath(user_fname:str, file_fname:str, extension:str, clip:int=None, a
             sys.exit(0)
         os.remove(filepath)
     return filepath
+
+
+def shift_time_delta(time_str:str, delta_second:int=0, with_ms:bool=False):
+    """
+    Shift given time by adding `delta_second` seconds (can be negative), then format it.
+    """
+    tmp_timedelta = parse_timedelta(time_str)
+    total_seconds = int(tmp_timedelta.total_seconds()) + delta_second
+    hours, rem = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(rem, 60)
+    output = f'{hours:02d}:{minutes:02d}:{seconds:02d}'
+    if with_ms:
+        output += f'.{tmp_timedelta.microseconds:03d}'
+    return output
+
+
+def parse_timedelta(value):
+    """
+    Convert input string to timedelta.
+
+    Supported strings are like `01:23:45.678`.
+    """
+    value = re.sub(r"[^0-9:.]", "", value)
+    if not value:
+        return
+    if "." in value:
+        ms = int(value.split(".")[1])
+        value = value.split(".")[0]
+    else:
+        ms = 0
+    delta = datetime.timedelta(**{
+        key:float(val)
+        for val, key in zip(value.split(":")[::-1],
+                            ("seconds", "minutes", "hours", "days"))
+    })
+    delta += datetime.timedelta(microseconds=ms)
+    return delta

--- a/zoom_dl/zoomdl.py
+++ b/zoom_dl/zoomdl.py
@@ -110,7 +110,7 @@ class ZoomDL():
                     chats.append(message)
                 except demjson.JSONDecodeError:
                     self._print("[WARNING] Error with the meta parsing. This "
-                                "should not be critical. Please contact a dev. " + matched_json, 2)
+                                "should not be critical. Please contact a dev.", 2)
         else:
             self._print("Unable to extract chatList from page", 0)
         meta["chatList"] = chats


### PR DESCRIPTION
**What is this PR doing**

**Major improvement**: Chat messages and audio transcripts are now possible to be saved *(by wrangling with regexps :-) )*.

**Refactored implementation of `--filename-add-date`:**
The past implementation of appending the date is retrieving from `metadata["r_meeting_start_time"]`, which is only accessible by passing an invalid UA to Zoom. The disadvantage is that we are losing a lot of interesting metadata (including chat messages and audio transcripts).
The new implementation retrieves the timestamp of **the recording's starting time** from `metadata["fileStartTime"]`. In this way, we can continue using valid UAs and not losing metadata. Note that "the recording's start time" is different from "the meeting's start time", which I believe is acceptable for most cases.

**Known issues**

**The time of extracted chat messages may be inaccurate (usually faster than the video).** This situation happens when a cloud recording started during the meeting (but not when the meeting started), in this case chat messages were timed base on the meeting's start time.
To solve this, we need to find the meeting's start time and the recording's start time, then shift all messages' time by the difference between these two time. Currently I cannot find the meeting's start time from metadata. Maybe calling other APIs are needed.