### PR TITLE
fix issue #84, make regex lazy not greedy

### DIFF
--- a/zoom_dl/zoomdl.py
+++ b/zoom_dl/zoomdl.py
@@ -86,7 +86,7 @@ class ZoomDL():
         meta = dict(re.findall(r'type="hidden" id="([^"]*)" value="([^"]*)"',
                                text))
         # if javascript was correctly loaded, look for injected metadata
-        meta2_match = re.search("window.__data__ = ({(?:.*\n)*});",
+        meta2_match = re.search("window.__data__ = ({(?:.*\n)*?});",
                                 self.page.text)
         if meta2_match is not None:
             try:


### PR DESCRIPTION
Made the regex match lazy instead of greedy to prevent it from grabbing other variables.